### PR TITLE
Replace un-sanitized range calls with xrange calls, to neutralize a potential attack vector

### DIFF
--- a/messaging/mms/mms_pdu.py
+++ b/messaging/mms/mms_pdu.py
@@ -175,14 +175,14 @@ class MMSDecoder(wsp_pdu.Decoder):
         # <length of data>,
         # <content-type + other possible headers>,
         # <data>
-        for part_num in range(num_entries):
+        for part_num in xrange(num_entries):
             #print '\nPart %d:\n------' % part_num
             headers_len = self.decode_uint_var(data_iter)
             data_len = self.decode_uint_var(data_iter)
 
             # Prepare to read content-type + other possible headers
             ct_field_bytes = []
-            for i in range(headers_len):
+            for i in xrange(headers_len):
                 ct_field_bytes.append(data_iter.next())
 
             ct_iter = PreviewIterator(ct_field_bytes)
@@ -201,7 +201,7 @@ class MMSDecoder(wsp_pdu.Decoder):
 
             # Data (note: this is not null-terminated)
             data = array.array('B')
-            for i in range(data_len):
+            for i in xrange(data_len):
                 data.append(data_iter.next())
 
             part = message.DataPart()

--- a/messaging/mms/wsp_pdu.py
+++ b/messaging/mms/wsp_pdu.py
@@ -447,7 +447,7 @@ class Decoder:
 
         longInt = 0
         # Decode the Multi-octect-integer
-        for i in range(shortLength):
+        for i in xrange(shortLength):
             longInt = longInt << 8
             longInt |= byte_iter.next()
 
@@ -843,7 +843,7 @@ class Decoder:
 
         # Read parameters, etc, until <value_length> is reached
         ct_field_bytes = array.array('B')
-        for i in range(value_length):
+        for i in xrange(value_length):
             ct_field_bytes.append(byte_iter.next())
 
         ct_iter = PreviewIterator(ct_field_bytes)
@@ -1319,7 +1319,7 @@ class Decoder:
         hdr_fields = get_header_field_names()
         # TODO: *technically* this can fail, but then we have already
         # read a byte... should fix?
-        if field_value not in range(len(hdr_fields)):
+        if field_value not in xrange(len(hdr_fields)):
             raise DecodeError('Invalid Header Field value: %d' % field_value)
 
         field_name = hdr_fields[field_value]


### PR DESCRIPTION
Just try `x = range(1024*1024*1024)` on your own computer, if you want to see why...
