### PR TITLE
Multiple recipients

### DIFF
--- a/messaging/mms/message.py
+++ b/messaging/mms/message.py
@@ -36,6 +36,7 @@ class MMSMessage:
             'Message-Type': 'm-send-req',
             'Transaction-Id': '1234',
             'MMS-Version': '1.0',
+            'To': [],
             'Content-Type': ('application/vnd.wap.multipart.mixed', {}),
         }
         self.width = 176

--- a/messaging/mms/mms_pdu.py
+++ b/messaging/mms/mms_pdu.py
@@ -994,3 +994,37 @@ class MMSEncoder(wsp_pdu.Encoder):
 
         # Return an unrecognised state if it couldn't be decoded
         return [status_values.get(status_value, 'Unrecognised')]
+    
+    @staticmethod
+    def encode_expiry_value(expiry_value):
+        """
+        Encodes the expiry value for an MMS message using a relative token
+        (delta time), not an absolute token (fixed date and time)
+
+        encoding: [(total # of octets), (0x81), (# of octets in expiry value), (expiry value)]
+
+        Param: expiry_value
+        Precondition: expiry_value must be an base 10 integer representing the number
+        of seconds until the MMSC should delete an unaccepted MMS message
+        
+        Returns: Encoded expiry value
+        rtype: list of ints
+        """
+        assert type(expiry_value) == int
+
+        encoded_expiry_value = []
+        relativeToken = 129
+        hexValue = hex(expiry_value)[2:]
+        length = len(hexValue)
+
+        for x in range(length, 0, -2):
+            if x-2 < 0:
+                encoded_expiry_value.insert(0, int(hexValue[:x], 16))
+            else:
+                encoded_expiry_value.insert(0, int(hexValue[x-2:x], 16))
+
+        encoded_expiry_value.insert(0, len(encoded_expiry_value))
+        encoded_expiry_value.insert(0, relativeToken)
+        encoded_expiry_value.insert(0, len(encoded_expiry_value))
+
+        return encoded_expiry_value    

--- a/messaging/mms/mms_pdu.py
+++ b/messaging/mms/mms_pdu.py
@@ -999,37 +999,3 @@ class MMSEncoder(wsp_pdu.Encoder):
 
         # Return an unrecognised state if it couldn't be decoded
         return [status_values.get(status_value, 'Unrecognised')]
-    
-    @staticmethod
-    def encode_expiry_value(expiry_value):
-        """
-        Encodes the expiry value for an MMS message using a relative token
-        (delta time), not an absolute token (fixed date and time)
-
-        encoding: [(total # of octets), (0x81), (# of octets in expiry value), (expiry value)]
-
-        Param: expiry_value
-        Precondition: expiry_value must be an base 10 integer representing the number
-        of seconds until the MMSC should delete an unaccepted MMS message
-        
-        Returns: Encoded expiry value
-        rtype: list of ints
-        """
-        assert type(expiry_value) == int
-
-        encoded_expiry_value = []
-        relativeToken = 129
-        hexValue = hex(expiry_value)[2:]
-        length = len(hexValue)
-
-        for x in range(length, 0, -2):
-            if x-2 < 0:
-                encoded_expiry_value.insert(0, int(hexValue[:x], 16))
-            else:
-                encoded_expiry_value.insert(0, int(hexValue[x-2:x], 16))
-
-        encoded_expiry_value.insert(0, len(encoded_expiry_value))
-        encoded_expiry_value.insert(0, relativeToken)
-        encoded_expiry_value.insert(0, len(encoded_expiry_value))
-
-        return encoded_expiry_value    

--- a/messaging/mms/mms_pdu.py
+++ b/messaging/mms/mms_pdu.py
@@ -691,8 +691,13 @@ class MMSEncoder(wsp_pdu.Encoder):
         # -- this needs to be added last, according [2] and [4]
         for hdr in headers_to_encode:
             if hdr != 'Content-Type':
-                message_header.extend(
-                    MMSEncoder.encode_header(hdr, headers_to_encode[hdr]))
+                if hdr == 'To':
+                    for client in range(0, len(headers_to_encode[hdr])):
+                        message_header.extend(
+                                MMSEncoder.encode_header(hdr, headers_to_encode[hdr][client]))
+                else:
+                    message_header.extend(
+                        MMSEncoder.encode_header(hdr, headers_to_encode[hdr]))
 
         # Ok, now only "Content-type" should be left
         content_type, ct_parameters = headers_to_encode['Content-Type']


### PR DESCRIPTION
Multiple recipients cannot be specified in an MMS since the 'To' header is in a dictionary. The header is now initialized in the dictionary with a list where multiple recipients can be appended to (in class MMSMessage). In the method "encode_message_header" in the class MMSEncoder, the header 'To' is now iterated through for each value in the list so all recipients are encoded.